### PR TITLE
Session reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "cookie": "^0.5.0",
     "fastify-plugin": "^4.5.1",
     "nanoid": "3.3.5"
   },
@@ -43,6 +44,7 @@
     "@tsconfig/node-lts": "^18.12.5",
     "@tsconfig/strictest": "^2.0.2",
     "@types/benchmark": "^2.1.2",
+    "@types/cookie": "^0.5.2",
     "@types/node": "^18.17.14",
     "@types/sodium-native": "^2.3.5",
     "benchmark": "^2.1.4",

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -220,6 +220,21 @@ export class Session<T extends SessionData = SessionData> {
     await Session.#sessionStore.set(this.id, this.#sessionData, this.#expiry);
   }
 
+  /**
+   * Reload the session data from the session store. Only applicable for stateful sessions.
+   */
+  async reload(): Promise<void> {
+    if (Session.#sessionCrypto.stateless) {
+      return;
+    }
+    // Reload session from store
+    assert(Session.#sessionStore);
+    const session = await Session.fromStatelessCookie(this.id, this.rotated);
+    // not sure what to reset here?
+    // this.#sessionData = session.#sessionData;
+    return;
+  }
+
   get data(): SessionData {
     return this.#sessionData;
   }

--- a/src/typings/fastify.ts
+++ b/src/typings/fastify.ts
@@ -6,3 +6,9 @@ declare module "fastify" {
     destroySession: () => Promise<void>;
   }
 }
+
+declare module "http" {
+  interface IncomingMessage {
+    session: Session;
+  }
+}


### PR DESCRIPTION
This adds the ability for sessions to be also encoded and decoded by other packages as well as adding a session reload option. 

This was added because I've created (still wip) a package that allows these sessions to be used by socket.io as well (https://github.com/Menkveld-24/fastify-socketio-session). My package now uses this session package to decrypt a session and inserts it into socketio (using https://github.com/ducktors/fastify-socket.io). 

However these modifications to your package are quite generic and maybe useful to others as well. 

Let me know what you think of this